### PR TITLE
edit news, teaching, and ACL paper links

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,22 +178,19 @@
 
   <h2>Teaching</h2>
     <ul>
-        <li> Fall 2024, Special Lecture on Data Science (Multimodal model)</li>
-        <li> Fall 2024, Machine Learning and Deep Learning for Data Science 1 </li>
+        <li> Spring 2025, Special Topic: Multimodal model</li>
+        <li> Spring 2025, <a href="https://sites.google.com/view/ski-ml/courses/mldl1-spring-2025?authuser=0">Machine Learning and Deep Learning for Data Science 1</a></li>
+        <li> Fall 2024, Math and Statistics Foundations for Data Science </li>
+        <li> Fall 2024, <a href="https://leejayyoon.github.io/nlp-gsds/">NLP and its recent progress</a></li> 
         <li> Spring 2024, Math and Statistics Foundations for Data Science </li>
         <li> Spring 2024, Special Topic: Consistency in AI Models and LLMs </li>
         <li> Fall 2023, Math and Statistics Foundations for Data Science </li>
-        <li> Spring 2023, 
-    <a href="https://docs.google.com/spreadsheets/d/1t-1xihMCjPPSbBG6dG3OD-20d7TGPyWbBVEBqxxdbmU/edit#gid=0">Math and Statistics Foundations for Data Science (link to course schedule) </a></li>
-        <li> Fall 2022, 
-    <a href="https://leejayyoon.github.io/nlp-gsds/">NLP and its recent progress </a></li> 
-        <li> Spring 2015, 
-    <a href="http://alex.smola.org/teaching/10-701-15/">10-701 Introduction to Machine Learning </a></li> 
-    Teaching Assistant for Professor Alex J. Smola
-            </li>
-          <li> Fall 2014, 
-    <a href="http://www.cs.cmu.edu/~christos/courses/826.F14/">15-826 Multimedia Databases and Data Mining </a></li>
-    Teaching Assistant for Professor Christos Faloutsos
+        <li> Spring 2023, <a href="https://docs.google.com/spreadsheets/d/1t-1xihMCjPPSbBG6dG3OD-20d7TGPyWbBVEBqxxdbmU/edit#gid=0">Math and Statistics Foundations for Data Science (link to course schedule) </a></li>
+        <li> Fall 2022, <a href="https://leejayyoon.github.io/nlp-gsds/">NLP and its recent progress </a></li> 
+        <li> Spring 2015, <a href="http://alex.smola.org/teaching/10-701-15/">10-701 Introduction to Machine Learning </a></li> 
+            Teaching Assistant for Professor Alex J. Smola
+        <li> Fall 2014, <a href="http://www.cs.cmu.edu/~christos/courses/826.F14/">15-826 Multimedia Databases and Data Mining </a></li>
+            Teaching Assistant for Professor Christos Faloutsos
     </ul>
 
 <!--     <h2>Advising</h2>

--- a/index.html
+++ b/index.html
@@ -66,6 +66,10 @@
  -->      
      <h2>News</h2>
        <ul>
+        <li>07/14/25 1 intern has joined SKI-ML.</li> 
+        <li>07/03/25 1 intern has joined SKI-ML.</li> 
+        <li>06/25/25 2 interns have joined SKI-ML.</li> 
+        <li>06/12/25 5 graduate students have joined SKI-ML.</li> 
         <li>05/21/25 2 papers accepted at ACL 2025 (1 Oral)!</li>  
         <li>03/13/25 1 intern has joined our lab.</li>  
         <li>01/23/25 1 paper accepted at ICLR 2025!</li>  
@@ -173,7 +177,9 @@
         </ul>
 
   <h2>Teaching</h2>
-        <ul>
+    <ul>
+        <li> Fall 2024, Special Lecture on Data Science (Multimodal model)</li>
+        <li> Fall 2024, Machine Learning and Deep Learning for Data Science 1 </li>
         <li> Spring 2024, Math and Statistics Foundations for Data Science </li>
         <li> Spring 2024, Special Topic: Consistency in AI Models and LLMs </li>
         <li> Fall 2023, Math and Statistics Foundations for Data Science </li>
@@ -188,7 +194,7 @@
           <li> Fall 2014, 
     <a href="http://www.cs.cmu.edu/~christos/courses/826.F14/">15-826 Multimedia Databases and Data Mining </a></li>
     Teaching Assistant for Professor Christos Faloutsos
-        </ul>
+    </ul>
 
 <!--     <h2>Advising</h2>
     <ul>

--- a/publication.html
+++ b/publication.html
@@ -39,7 +39,7 @@
       <h2 style = "text-align: right;"><a href = "index.html">Home</a> &nbsp;&nbsp; <a href = "publication.html">Research</a> &nbsp;&nbsp; <a href = "https://sites.google.com/view/ski-ml/home?authuser=2">SKI-ML lab</a></h2>
       <h1 style = "text-align: center;">Publications</h1>
       <p>- List of papers published/submitted to peer reviewed conferences/journals.</p>
-      <p>- Asterix (*) denotes joint first author, i.e., equal contribution.</p>
+      <p>- Asterisk (*) denotes joint first author, i.e., equal contribution.</p>
       <h2 style = "text-align: center;">Preprints</h2>
       <ul>
          <li><b>GraphCheck: Multi-Path Fact-Checking with Entity-Relationship Graphs </b><br>

--- a/publication.html
+++ b/publication.html
@@ -60,11 +60,11 @@
       <ul>
          <li><b>Introducing Verification Task of Set Consistency with Set-Consistency Energy Networks </b><br>
             Mooho Song, Hyeryung Son, <font color="blue">Jay-Yoon Lee</font> <br> <span style="font-style: italic;"> ACL 2025 (oral), July 2025 </span><br>
-            [<a href="https://arxiv.org/abs/2503.10695"> paper </a>]
+            [<a href="https://aclanthology.org/2025.acl-long.1599/"> paper </a>]
          </li>
          <li><b>BridG MT: Enhancing LLMs' Machine Translation Capabilities with Sentence Bridging and Gradual MT </b><br>
             Seung-Woo Choi, Gahyun Yoo, <font color="blue">Jay-Yoon Lee</font> <br> <span style="font-style: italic;"> Findings of ACL 2025, July 2025 </span><br>
-            [<a href="https://arxiv.org/abs/2410.11693"> paper </a>]
+            [<a href="https://aclanthology.org/2025.findings-acl.1336/"> paper </a>]
          </li>
          <li><b>CoMRes: Semi-Supervised Time Series Forecasting Utilizing Consensus Promotion of Multi-Resolution </b><br>
             Yunju Cho, <font color="blue">Jay-Yoon Lee</font> <br> <span style="font-style: italic;"> ICLR 2025, Apr 2025 </span><br>


### PR DESCRIPTION
**1. 뉴스에 다음 항목들을 추가했습니다.**
  -   07/14/25 1 intern has joined SKI-ML.
  -   07/03/25 1 intern has joined SKI-ML.
  -   06/25/25 2 interns have joined SKI-ML.
  -   06/12/25 5 graduate students have joined SKI-ML.
  
**2. Teaching에 다음 항목들을 추가했습니다.**
  - Spring 2025, Special Topic: Multimodal model
  - Spring 2025, [Machine Learning and Deep Learning for Data Science 1](https://sites.google.com/view/ski-ml/courses/mldl1-spring-2025?authuser=0)
  - Fall 2024, Math and Statistics Foundations for Data Science
  - Fall 2024, [NLP and its recent progress](https://leejayyoon.github.io/nlp-gsds/)
  
  **3. publications에 무호님, 승우님 논문을 arxiv 링크에서 ACL 링크로 수정했습니다.**
  **4. Publications 탭의 오타를 수정했습니다. (asterix -> asterisk)**
